### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/SoroushBeigi/simple-bank-go/security/code-scanning/1](https://github.com/SoroushBeigi/simple-bank-go/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations (checking out code, running migrations, and tests), the `contents: read` permission is sufficient. This ensures that the workflow can read the repository contents without granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
